### PR TITLE
Initialize a variable (for `python3` branch)

### DIFF
--- a/cindex.py
+++ b/cindex.py
@@ -2302,6 +2302,7 @@ class TranslationUnit(ClangObject):
         if isinstance(filename, str):
             filename = filename.encode('utf8')
 
+        args_array = None
         args_length = len(args)
         if args_length > 0:
             args = (arg.encode('utf8') if isinstance(arg, str) else arg


### PR DESCRIPTION
Could you please make the #1 fix in `python3` branch as well? (~We are using `python3` in our code, sorry about that~).
Same as #1, but against `python3` instead of `master`. 

> Do you think we missed the initialization in this commit?
> 9834d19#diff-a4a8131455a0644a742ad612f6f05b04
>
> LLVM's version: https://github.com/llvm-mirror/clang/blob/master/bindings/python/clang/cindex.py#L2813

